### PR TITLE
Require `ot-json1` >= 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "eslint": "^5.16.0",
     "immutable": "^4.0.0-rc.12",
     "jest": "^24.7.1",
-    "ot-json1": "^0.2.4",
+    "ot-json1": "1.0.1",
     "prettier": "^1.19.1",
     "rich-text": "^3.1.0"
   },
   "peerDependencies": {
     "immutable": ">= 3.0",
-    "ot-json1": "*"
+    "ot-json1": ">= 1.0"
   },
   "jest": {
     "roots": [

--- a/src/apply/__tests__/apply.spec.js
+++ b/src/apply/__tests__/apply.spec.js
@@ -1,7 +1,9 @@
 import { insertOp, moveOp, editOp, removeOp, replaceOp, type } from "ot-json1";
 import { fromJS, Set, Map } from "immutable";
 import Delta from "quill-delta";
-import apply, { registerSubtype } from "..";
+import otJSON1Immutable from "../..";
+const apply = otJSON1Immutable.type.applyImmutable;
+const registerSubtype = otJSON1Immutable.type.registerSubtype;
 
 describe("insertOp", () => {
   it("inserts at root", () => {
@@ -94,9 +96,10 @@ describe("editOp", () => {
 
   it("throws when ot type is unknown", () => {
     const input = fromJS({ a: ["Foo"] });
-    const op = editOp(["a", 0], "custom-type", ["edit"]);
 
-    expect(() => apply(input, op)).toThrow("Missing type: custom-type");
+    expect(() =>
+      apply(input, editOp(["a", 0], "custom-type", ["edit"]))
+    ).toThrow("Missing type: custom-type");
   });
 });
 

--- a/src/apply/__tests__/apply.spec.js
+++ b/src/apply/__tests__/apply.spec.js
@@ -1,10 +1,10 @@
-import { insertOp, moveOp, editOp, removeOp, replaceOp, type } from 'ot-json1';
-import { fromJS, Set, Map } from 'immutable';
-import Delta from 'quill-delta';
-import apply, { registerSubtype } from '..';
+import { insertOp, moveOp, editOp, removeOp, replaceOp, type } from "ot-json1";
+import { fromJS, Set, Map } from "immutable";
+import Delta from "quill-delta";
+import apply, { registerSubtype } from "..";
 
-describe('insertOp', () => {
-  it('inserts at root', () => {
+describe("insertOp", () => {
+  it("inserts at root", () => {
     const input = undefined;
     const output = fromJS([1]);
     const op = insertOp([], [1]);
@@ -12,33 +12,33 @@ describe('insertOp', () => {
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('inserts inside Map', () => {
+  it("inserts inside Map", () => {
     const input = fromJS({ a: { b: 1 } });
     const output = fromJS({ a: { b: 1, c: 2 } });
-    const op = insertOp(['a', 'c'], 2);
+    const op = insertOp(["a", "c"], 2);
 
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('inserts inside List', () => {
+  it("inserts inside List", () => {
     const input = fromJS({ a: [1] });
     const output = fromJS({ a: [2, 1] });
-    const op = insertOp(['a', 0], 2);
+    const op = insertOp(["a", 0], 2);
 
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('inserts inside a Set', () => {
-    const input = Map({a: Set([1])});
-    const output = Map({a: Set([1,2])});
-    const op = insertOp(['a', 0], 2);
+  it("inserts inside a Set", () => {
+    const input = Map({ a: Set([1]) });
+    const output = Map({ a: Set([1, 2]) });
+    const op = insertOp(["a", 0], 2);
 
     expect(apply(input, op)).toEqual(output);
   });
 });
 
-describe('moveOp', () => {
-  it('moves nodes on same level at root', () => {
+describe("moveOp", () => {
+  it("moves nodes on same level at root", () => {
     const input = fromJS([1, 2]);
     const output = fromJS([2, 1]);
     const op = moveOp([0], [1]);
@@ -46,62 +46,62 @@ describe('moveOp', () => {
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('moves nodes on same nested level', () => {
+  it("moves nodes on same nested level", () => {
     const input = fromJS({ a: [1, 2] });
     const output = fromJS({ a: [2, 1] });
-    const op = moveOp(['a', 0], ['a', 1]);
+    const op = moveOp(["a", 0], ["a", 1]);
 
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('moves nodes on different level', () => {
+  it("moves nodes on different level", () => {
     const input = fromJS({ a: [1, 2], b: [3] });
     const output = fromJS({ a: [1], b: [2, 3] });
-    const op = moveOp(['a', 1], ['b', 0]);
+    const op = moveOp(["a", 1], ["b", 0]);
 
     expect(apply(input, op)).toEqual(output);
   });
 });
 
-describe('editOp', () => {
-  it('edits nodes with text-unicode ot type', () => {
-    const input = fromJS({ a: ['Foo'] });
-    const output = fromJS({ a: ['Foo Bar'] });
-    const op = editOp(['a', 0], 'text-unicode', [3, ' Bar']);
+describe("editOp", () => {
+  it("edits nodes with text-unicode ot type", () => {
+    const input = fromJS({ a: ["Foo"] });
+    const output = fromJS({ a: ["Foo Bar"] });
+    const op = editOp(["a", 0], "text-unicode", [3, " Bar"]);
 
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('edits nodes with number ot type', () => {
+  it("edits nodes with number ot type", () => {
     const input = fromJS({ a: [1] });
     const output = fromJS({ a: [2] });
-    const op = editOp(['a', 0], 'number', 1);
+    const op = editOp(["a", 0], "number", 1);
 
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('edits nodes with registered ot type', () => {
-    registerSubtype(require('rich-text'));
-    const input = fromJS({ a: [new Delta([{ insert: 'Foo' }])] });
-    const output = fromJS({ a: [new Delta([{ insert: 'Foo Bar' }])] });
-    const op = editOp(['a', 0], 'rich-text', [
+  it("edits nodes with registered ot type", () => {
+    registerSubtype(require("rich-text"));
+    const input = fromJS({ a: [new Delta([{ insert: "Foo" }])] });
+    const output = fromJS({ a: [new Delta([{ insert: "Foo Bar" }])] });
+    const op = editOp(["a", 0], "rich-text", [
       { retain: 3 },
-      { insert: ' Bar' },
+      { insert: " Bar" }
     ]);
 
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('throws when ot type is unknown', () => {
-    const input = fromJS({ a: ['Foo'] });
-    const op = editOp(['a', 0], 'custom-type', ['edit']);
+  it("throws when ot type is unknown", () => {
+    const input = fromJS({ a: ["Foo"] });
+    const op = editOp(["a", 0], "custom-type", ["edit"]);
 
-    expect(() => apply(input, op)).toThrow('Missing type: custom-type');
+    expect(() => apply(input, op)).toThrow("Missing type: custom-type");
   });
 });
 
-describe('removeOp', () => {
-  it('removes at root', () => {
+describe("removeOp", () => {
+  it("removes at root", () => {
     const input = fromJS({ a: {} });
     const output = undefined;
     const op = removeOp([]);
@@ -109,94 +109,97 @@ describe('removeOp', () => {
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('removes nested', () => {
+  it("removes nested", () => {
     const input = fromJS({ a: { b: {} } });
     const output = fromJS({ a: {} });
-    const op = removeOp(['a', 'b']);
+    const op = removeOp(["a", "b"]);
 
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('removes nested and all its children', () => {
+  it("removes nested and all its children", () => {
     const input = fromJS({ a: { b: { c: [1, 2] } } });
     const output = fromJS({ a: {} });
-    const op = removeOp(['a', 'b']);
+    const op = removeOp(["a", "b"]);
 
     expect(apply(input, op)).toEqual(output);
   });
 });
 
-describe('replaceOp', () => {
-  it('replaces at root', () => {
+describe("replaceOp", () => {
+  it("replaces at root", () => {
     const input = fromJS({ a: 1 });
-    const output = fromJS(['b', 1]);
-    const op = replaceOp([], { a: 1 }, ['b', 1]);
+    const output = fromJS(["b", 1]);
+    const op = replaceOp([], { a: 1 }, ["b", 1]);
 
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('replaces nested', () => {
+  it("replaces nested", () => {
     const input = fromJS({ a: { b: 1 } });
     const output = fromJS({ a: { c: 2 } });
-    const op = replaceOp(['a'], { b: 1 }, { c: 2 });
+    const op = replaceOp(["a"], { b: 1 }, { c: 2 });
 
     expect(apply(input, op)).toEqual(output);
   });
 });
 
-describe('fancy tests', () => {
-  it('handles composed operations', () => {
-    registerSubtype(require('rich-text'));
+describe("fancy tests", () => {
+  it("handles composed operations", () => {
+    registerSubtype(require("rich-text"));
 
     const input = fromJS([9]);
     const output = fromJS({
-      a: new Delta([{ insert: 'Foo Bar' }]),
+      a: new Delta([{ insert: "Foo Bar" }]),
       b: 8,
-      c: 'Foo Bar',
+      c: "Foo Bar"
     });
 
     const op = [
-      [{ r: [], i: {} }, [0, { p: 0 }], ['b', { d: 0 }]],
-      editOp(['b'], 'number', -1),
-      insertOp(['a'], new Delta()),
-      editOp(['a'], 'rich-text', [{ insert: 'Foo Bar' }]),
-      insertOp(['c'], ''),
-      editOp(['c'], 'text-unicode', ['Foo Bar']),
+      [{ r: [], i: {} }, [0, { p: 0 }], ["b", { d: 0 }]],
+      editOp(["b"], "number", -1),
+      insertOp(["a"], new Delta()),
+      editOp(["a"], "rich-text", [{ insert: "Foo Bar" }]),
+      insertOp(["c"], ""),
+      editOp(["c"], "text-unicode", ["Foo Bar"])
     ].reduce(type.compose, null);
 
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('converts {x: {y: {}}} to {X: {Y: {}}}', () => {
+  it("converts {x: {y: {}}} to {X: {Y: {}}}", () => {
     const input = fromJS({ x: { y: {} } });
     const output = fromJS({ X: { Y: {} } });
-    const op = [['x', { p: 0 }, 'y', { p: 1 }], ['X', { d: 0 }, 'Y', { d: 1 }]];
+    const op = [
+      ["x", { p: 0 }, "y", { p: 1 }],
+      ["X", { d: 0 }, "Y", { d: 1 }]
+    ];
 
     expect(apply(input, op)).toEqual(output);
   });
 
-  it('converts {x:10,y:20,z:30} to [10,20,30]', () => {
+  it("converts {x:10,y:20,z:30} to [10,20,30]", () => {
     const input = fromJS({ x: 10, y: 20, z: 30 });
     const output = fromJS([10, 20, 30]);
     const op = [
       { r: {}, i: [] },
-      ['x', { p: 0 }],
-      ['y', { p: 1 }],
-      ['z', { p: 2 }],
+      ["x", { p: 0 }],
+      ["y", { p: 1 }],
+      ["z", { p: 2 }],
       [0, { d: 0 }],
       [1, { d: 1 }],
-      [2, { d: 2 }],
+      [2, { d: 2 }]
     ];
 
     expect(apply(input, op)).toEqual(output);
   });
 
   it('converts {x:{y:{secret:"data"}}} to {y:{x:{secret:"data"}}}', () => {
-    const input = fromJS({ x: { y: { secret: 'data' } } });
-    const output = fromJS({ y: { x: { secret: 'data' } } });
+    const input = fromJS({ x: { y: { secret: "data" } } });
+    const output = fromJS({ y: { x: { secret: "data" } } });
     const op = [
-      ['x', [{ r: {} }, ['y', { p: 0 }]]],
-      ['y', [{ i: {} }, ['x', { d: 0 }]]],
+      ["x", [{ r: {} }, ["y", { p: 0 }]]],
+      ["y", [{ i: {} }, ["x", { d: 0 }]]]
     ];
 
     expect(apply(input, op)).toEqual(output);

--- a/src/apply/helpers.js
+++ b/src/apply/helpers.js
@@ -1,7 +1,7 @@
-import json1 from 'ot-json1';
+import json1 from "ot-json1";
 
 export const isPath = p => Array.isArray(p);
-export const isAction = p => typeof p === 'object';
+export const isAction = p => typeof p === "object";
 export const hasPick = a => a && a.p != null;
 export const hasDrop = a => a && a.d != null;
 export const hasInsert = a => a && a.i != null;
@@ -18,7 +18,7 @@ export function getEditType(a) {
     }
     return SUBTYPES[a.et];
   } else if (a.es) {
-    return SUBTYPES['text-unicode'];
+    return SUBTYPES["text-unicode"];
   } else if (a.ena) {
     return SUBTYPES.number;
   }
@@ -36,12 +36,12 @@ export function registerSubtype(subtype) {
   json1.type.registerSubtype(subtype);
 }
 
-registerSubtype(require('ot-text-unicode'));
+registerSubtype(require("ot-text-unicode"));
 
 const add = (a, b) => a + b;
 registerSubtype({
-  name: 'number',
+  name: "number",
   apply: add,
   compose: add,
-  transform: a => a,
+  transform: a => a
 });

--- a/src/apply/helpers.js
+++ b/src/apply/helpers.js
@@ -1,4 +1,4 @@
-import json1 from "ot-json1";
+import * as json1 from "ot-json1";
 
 export const isPath = p => Array.isArray(p);
 export const isAction = p => typeof p === "object";

--- a/src/apply/index.js
+++ b/src/apply/index.js
@@ -1,7 +1,7 @@
-import pick from './pick';
-import drop from './drop';
+import pick from "./pick";
+import drop from "./drop";
 
-import { registerSubtype } from './helpers';
+import { registerSubtype } from "./helpers";
 
 function apply(snapshot, op, reviver) {
   if (op === null) return snapshot;

--- a/src/apply/pick.js
+++ b/src/apply/pick.js
@@ -1,4 +1,4 @@
-import { isPath, isAction, hasPick, hasRemove } from './helpers';
+import { isPath, isAction, hasPick, hasRemove } from "./helpers";
 
 export default function pick(held, fragment, path) {
   const actions = [];

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import json1 from "ot-json1";
+import * as json1 from "ot-json1";
 import applyImmutable, { registerSubtype } from "./apply";
 
 export default {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import json1 from 'ot-json1';
-import applyImmutable, { registerSubtype } from './apply';
+import json1 from "ot-json1";
+import applyImmutable, { registerSubtype } from "./apply";
 
 export default {
   ...json1,
-  type: { ...json1.type, applyImmutable, registerSubtype },
+  type: { ...json1.type, applyImmutable, registerSubtype }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3522,19 +3522,19 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-ot-json1@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/ot-json1/-/ot-json1-0.2.4.tgz#2e524eb5c59d5f9cb48d95edc0c54ef40e12d3a3"
-  integrity sha512-nVZPpPZDBwZo2VrmZzFX3PTusEX0E1esbqMqo8sM9tRDzMFgRMQLssSmxG1nKL43ycbECJywepAAWfsRzUWFUQ==
+ot-json1@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ot-json1/-/ot-json1-1.0.1.tgz#294ec53857493d7dc76bbfa338d34c31a67ead22"
+  integrity sha512-UWZxuZ1v3QYq2Rip3TD5rGxGPZscukB4qo5hwu6gP4gcB/wxExI7LoZen4ezxltB9JdkDmmMI6ihFQxbW+EmZQ==
   dependencies:
-    ot-text-unicode "^3.0.0"
+    ot-text-unicode "4"
 
-ot-text-unicode@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ot-text-unicode/-/ot-text-unicode-3.0.0.tgz#95a0e762227e554567db70ed022afa08ea4faa6b"
-  integrity sha512-YwVxEFVLV9WE40KavenjlHy3Y0C2OZoJeNCHKEpJlmu/scJaY9tlSrlYNBU7WJgboIz/IoKsd0Poxf+SYLRmrw==
+ot-text-unicode@4:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ot-text-unicode/-/ot-text-unicode-4.0.0.tgz#778a327535c81ed265b36ebe1bd677f31bae1e32"
+  integrity sha512-W7ZLU8QXesY2wagYFv47zErXud3E93FGImmSGJsQnBzE+idcPPyo2u2KMilIrTwBh4pbCizy71qRjmmV6aDhcQ==
   dependencies:
-    unicount "^1.0.0"
+    unicount "1.1"
 
 output-file-sync@^2.0.0:
   version "2.0.1"
@@ -4573,10 +4573,10 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
   integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
 
-unicount@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unicount/-/unicount-1.0.0.tgz#647e27d960b0468eec447da4575e9787a9fdab63"
-  integrity sha512-laO0gw4tnW759KI25w8z+58D4K+pnXehZvfKdFj3meYn/NSH85/0I8Gb4jj32tuZaX7zv1rSeP2K87rdChIZUw==
+unicount@1.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unicount/-/unicount-1.1.0.tgz#396a3df661c19675a93861ac878c2c9c0042abf0"
+  integrity sha512-RlwWt1ywVW4WErPGAVHw/rIuJ2+MxvTME0siJ6lk9zBhpDfExDbspe6SRlWT3qU6AucNjotPl9qAJRVjP7guCQ==
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The first commit is just some prettifycation. 


The second is more interesting, I think to handle `ot-json1` >= 1 we need to update the way we import it.

What do you think?